### PR TITLE
Fix for stoping nova-compute service

### DIFF
--- a/pcmk/NovaCompute
+++ b/pcmk/NovaCompute
@@ -188,7 +188,7 @@ nova_stop() {
     pid=`nova_pid`
 
     nova_monitor
-    if [ $? != $OCF_SUCCESS ]; then
+    if [ $? = $OCF_SUCCESS ]; then
 	if [ 0 = 1 ]; then
 	    # Apparently this is a bad idea...
 	    #
@@ -218,9 +218,10 @@ nova_stop() {
 	fi
 
 	# Then stop
-	su nova -c "kill -TERM $pid"
-
-	rc=$OCF_ERR_GENERIC
+	su nova -c "kill -TERM $pid" -s /bin/bash
+	
+	nova_monitor
+	rc=$
 	while [ $rc = $OCF_SUCCESS ]; do
 	    nova_monitor
 	    rc=$?


### PR DESCRIPTION
This simple fix is for actually stopping nova service when nova_monitor returns OCF_SUCCESS.
