### PR TITLE
Asynchronous way of performing evacuate

### DIFF
--- a/pcmk/async_evacuate.py
+++ b/pcmk/async_evacuate.py
@@ -5,6 +5,8 @@ import threading
 import logging
 import shlex
 import sys
+sys.path.append("/usr/share/fence")
+from fencing import SyslogLibHandler
 
 
 class AsyncEvacuate():
@@ -16,7 +18,6 @@ class AsyncEvacuate():
         :return: None
         """
 
-        logging.basicConfig(filename='/tmp/async_evacuate.log', level=logging.DEBUG)
         self._hostname = str(hostname)
         self._command = command
         self._timeout = timeout
@@ -106,7 +107,11 @@ class AsyncEvacuate():
 
 
 def main():
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger().addHandler(SyslogLibHandler())
+
     if len(sys.argv) != 3:
+        logging.info("Not enough parameters")
         sys.exit(1)
 
     hostname, command = sys.argv[1:]

--- a/pcmk/async_evacuate.py
+++ b/pcmk/async_evacuate.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python -tt
+
+import subprocess
+import threading
+import logging
+import shlex
+import sys
+
+
+class AsyncEvacuate():
+
+    def __init__(self, hostname, command, timeout=5):
+        """
+        :param hostname: name of host from which we will evacuate
+        :param command: command to perform
+        :return: None
+        """
+
+        logging.basicConfig(filename='/tmp/async_evacuate.log', level=logging.DEBUG)
+        self._hostname = str(hostname)
+        self._command = command
+        self._timeout = timeout
+
+    def run(self):
+        """
+        This disables host in pacemaker
+        then evacuate all the vm's
+        at last it enables host again
+        :return: None
+        """
+
+        try:
+            self._disable_host()
+            self._run_command()
+        except Exception as err:
+            logging.error("Evacuating failed due to error")
+            logging.debug(str(err))
+        finally:
+            self._enable_host()
+
+    @staticmethod
+    def run_process(command, timeout):
+        """
+        Runs process for given amount of time, then kills it
+        :return: process.wait() if process exited normally, 1 if it was killed
+        :rtype int
+        """
+        process = subprocess.Popen(shlex.split(command))
+
+        thread = threading.Thread(target=process.wait)
+        thread.start()
+        thread.join(timeout)
+
+        if thread.is_alive():
+            process.kill()
+            return 1
+
+        return process.wait()
+
+    def _disable_host(self):
+        """
+        Disables host in pacemaker
+        :return: None
+        """
+
+        command = "pcs resource disable %s" % self._hostname
+        logging.info("Disabling host %s in pacemaker" % self._hostname)
+
+        # if run_process returns 1, it was killed - therefore Exception is raised
+        if AsyncEvacuate.run_process(command, self._timeout):
+            msg = "Cannot disable host in pacemaker"
+            raise Exception(msg)
+
+        logging.info("Host %s disabled in pacemaker" % self._hostname)
+
+    def _run_command(self):
+        """
+        Evacuates all VMs from given host
+        :return: None
+        """
+
+        logging.info("Evacuating vms from host %s" % self._hostname)
+
+        process = subprocess.Popen(shlex.split(self._command))
+        # theoretically call to nova always ends
+        # but maybe some big timeout shall be added?
+        process.wait()
+
+        logging.info("Evacuating vms from host %s ended" % self._hostname)
+
+    def _enable_host(self):
+        """
+        Enables host in pacemaker
+        :return: None
+        """
+
+        command = "pcs resource enable %s" % self._hostname
+        logging.info("Enabling host %s in pacemaker" % self._hostname)
+
+        # if run_process returns 1, it was killed - therefore Exception is raised
+        if AsyncEvacuate.run_process(command, self._timeout):
+            msg = "Cannot enable host in pacemaker"
+            raise Exception(msg)
+
+        logging.info("Host %s enabled in pacemaker" % self._hostname)
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(1)
+
+    hostname, command = sys.argv[1:]
+    ae = AsyncEvacuate(hostname, command)
+    ae.run()
+
+if __name__ == "__main__":
+    main()

--- a/pcmk/fence_compute
+++ b/pcmk/fence_compute
@@ -6,6 +6,7 @@ from pipes import quote
 sys.path.append("/usr/share/fence")
 from fencing import *
 from fencing import fail_usage, is_executable, run_command, run_delay
+import subprocess
 
 #BEGIN_VERSION_GENERATION
 RELEASE_VERSION="4.0.11"
@@ -73,9 +74,9 @@ def set_power_status(_, options):
                 # storage in use, then they get what they asked for
                 evacuate += " --on-shared-storage"
 
-        evacuate += " --host " + options["--plug"]
+        evacuate += options["--plug"]
 
-        (ret, stdout, stderr) = run_command(options, create_command(options, evacuate))
+        subprocess.Popen(['async_evacuate.py', options["--plug"], create_command(options, evacuate)])
 
         return
 

--- a/pcmk/fence_compute
+++ b/pcmk/fence_compute
@@ -74,7 +74,7 @@ def set_power_status(_, options):
                 # storage in use, then they get what they asked for
                 evacuate += " --on-shared-storage"
 
-        evacuate += options["--plug"]
+        evacuate += " " + options["--plug"]
 
         subprocess.Popen(['async_evacuate.py', options["--plug"], create_command(options, evacuate)])
 


### PR DESCRIPTION
This is a draft version of asynchronous evacuate.
If there is a lot of VM's there is a risk that we've got timeout while evacuating. Since evacuating is synchronous process, there is no way to calculate right timeout value. Because of that, I have prepared idea of the solution.

First module async_evacuate.py must be put in system PATH.
Then it is called in fence_compute script instead of run_command.
This will prevent from timeout failure while evacuating big amount of VMs, since it's not blocking.

How it works:
1. Disable host in pacemaker
2. Evacuate all the vm's
3. Enable host again in pacemaker

For make it work, you will need to approve my previous pull requests. 
