### PR TITLE
Asynchronous way of performing evacuate version 2

### DIFF
--- a/pcmk/fence_compute
+++ b/pcmk/fence_compute
@@ -1,5 +1,6 @@
 #!/usr/bin/python -tt
-
+import shlex
+import subprocess
 import sys
 import time
 import atexit
@@ -77,7 +78,7 @@ def set_power_status(_, options):
 
         evacuate += " " + options["--plug"]
 
-        (ret, stdout, stderr) = run_command(options, create_command(options, evacuate))
+        subprocess.Popen(shlex.split(create_command(options, evacuate)))
 
         return
 

--- a/pcmk/fence_compute
+++ b/pcmk/fence_compute
@@ -75,7 +75,7 @@ def set_power_status(_, options):
                 # storage in use, then they get what they asked for
                 evacuate += " --on-shared-storage"
 
-        evacuate += " --host " + options["--plug"]
+        evacuate += " " + options["--plug"]
 
         (ret, stdout, stderr) = run_command(options, create_command(options, evacuate))
 


### PR DESCRIPTION
This is a draft version 2 of asynchronous evacuate.

As determined on today call, there is no need for disabling host before starting evacuation. If host works fine after fencing, there is no reason for evacuating VMs onto other node. Nevertheless, if there is something seriously wrong with host (reboot won't help), we will need to evacuate all of the VM's, which may cause time out. All in all, previous attempt with additional script may be rejected, but call to nova API must be asynchronous.
