### PR TITLE
Run evacuation asynchronously, so it can evacuate 30+ vms

### DIFF
--- a/pcmk/async_evacuate.py
+++ b/pcmk/async_evacuate.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python -tt
+
+import logging
+import sys
+import getopt
+import time
+sys.path.append("/usr/share/fence")
+from fencing import SyslogLibHandler
+from novaclient import client
+
+
+class AsyncEvacuate():
+
+    def __init__(self, hostname, user, password, tenant, auth_url, attempt_num=60):
+        """
+        :param hostname: name of host from which we will evacuate
+        :param attempt_num: how many times try to evacuate VMs
+        :return: None
+        """
+
+        self._hostname = str(hostname)
+        self._attempt_num = attempt_num
+        self._nova = client.Client(2, user, password, tenant, auth_url)
+
+    def host_evacuate(self, on_shared_storage):
+        """
+        This tries to evacuate instances from host
+        as long as host is down
+        :param on_shared_storage: tells if shared storage is used
+        :return: None
+        """
+        nova = self._nova
+        attempts = 0
+
+        self._wait_for_host_state("down")
+
+        while attempts < self._attempt_num:
+            try:
+                host = nova.hypervisors.search(self._hostname)[0]
+                servers = self.get_active_instances()
+                if servers and host.state is not 'up':
+                    for server in servers:
+                        server.evacuate(on_shared_storage=on_shared_storage)
+                    break
+                elif host.state is 'up':
+                    break
+            except Exception as e:
+                time.sleep(1)
+                logging.debug("Cannot evacuate due to: %s" % str(e))
+            finally:
+                attempts += 1
+
+        if attempts == self._attempt_num:
+            logging.info("Cannot evacuate VMs after %s attempts" % str(self._attempt_num))
+        else:
+            logging.info("VMs successfully evacuated")
+
+    def get_active_instances(self):
+        """
+        Return list of active instances running on host
+        :return: List of active instances running on host
+        :rtype: list
+        """
+        return self._nova.servers.list(search_opts={
+            'host': self._hostname,
+            'status': 'ACTIVE'})
+
+    def _wait_for_host_state(self, state):
+        """
+        Waits till host is in given state
+        :param state: wanted state of host
+        :return: None
+        """
+        logging.debug("Wait for host to have state: %s" % state)
+        nova = self._nova
+        end = False
+        # some kind of timeout shall be added?
+        while not end:
+            try:
+                logging.debug('Waiting for nova to update it internal state')
+                services = nova.services.list(self._hostname)
+                for service in services:
+                    if service.binary == "nova-compute" and service.state == state:
+                        end = True
+                        break
+                time.sleep(1)
+            except Exception as e:
+                logging.debug("Exception %s" % str(e))
+                time.sleep(1)
+
+
+def main(argv):
+    logging.basicConfig(level=logging.DEBUG)
+    logging.getLogger().addHandler(SyslogLibHandler())
+    param_dict = {
+        "--user": None,
+        "--pass": None,
+        "--tenant": None,
+        "--name": None,
+        "--auth_url": None,
+        "--on_shared_storage": None
+    }
+
+    try:
+        opts, args = getopt.getopt(argv, "",
+                                   ["user=",
+                                   "pass=",
+                                   "tenant=",
+                                   "name=",
+                                   "auth_url=",
+                                   "on_shared_storage="])
+    except getopt.GetoptError:
+        logging.info("Wrong parameter passed into script")
+        sys.exit(2)
+
+    for opt, arg in opts:
+        param_dict[opt] = arg
+
+    for key, value in param_dict.items():
+        if value is None:
+            logging.info("value of %s is not set" % key)
+            sys.exit(1)
+
+    ae = AsyncEvacuate(param_dict["--name"],
+                       param_dict["--user"],
+                       param_dict["--pass"],
+                       param_dict["--tenant"],
+                       param_dict["--auth_url"])
+    ae.host_evacuate(False if param_dict["--on_shared_storage"] == "False" else True)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/pcmk/fence_compute
+++ b/pcmk/fence_compute
@@ -94,23 +94,29 @@ def set_power_status(_, options):
                         override_status = "on"
                 return
 
-        # need to wait for nova to update its internal status or we
-        # cannot call host-evacuate
-        while get_power_status(_, options) != "off":
-                # Loop forever if need be.
-                #
-                # Some callers (such as Pacemaker) will have a timer
-                # running and kill us if necessary
-                logging.debug("Waiting for nova to update it's internal state")
-                time.sleep(1)
-
+        override_status = "off"
         if "--no-shared-storage" not in options:
-            # If the admin sets this when they DO have shared
-            # storage in use, then they get what they asked for
-            on_shared_storage = True
+                # If the admin sets this when they DO have shared
+                # storage in use, then they get what they asked for
+                on_shared_storage = True
         else:
-            on_shared_storage = False
-        _host_evacuate(options["--plug"], on_shared_storage)
+                on_shared_storage = False
+
+        # run script that will try to evacuate vms as long as host is down
+        subprocess.Popen(["python",
+                          "/usr/share/fence/async_evacuate.py",
+                          "--user",
+                          options["--username"],
+                          "--pass",
+                          options["--password"],
+                          "--tenant",
+                          options["--tenant-name"],
+                          "--auth_url",
+                          options["--auth-url"],
+                          "--name",
+                          options["--plug"],
+                          "--on_shared_storage",
+                          str(on_shared_storage)])
 
         return
 


### PR DESCRIPTION
This brings back evacuating VM's asynchronously, since if we do not do it, timeout will be reached if there is a lot of instances on dead host.

Also, move 'wait for nova to update it internal state' part outside the fencing script, so it should cover simultaneous compute and controller failure problem. Even if we want to resolve it another way, evacuation itself cannot be run inside fencing script, cause for a lot of VMs it can take very long.
