### PR TITLE
Rename resources to be closer to tripleo

### DIFF
--- a/pcmk/ceilometer.scenario
+++ b/pcmk/ceilometer.scenario
@@ -3,7 +3,7 @@
 # of nodes you'd like it to modify.
 #
 # The scope of each command-block is controlled by the preceeding
-# 'target' line. 
+# 'target' line.
 #
 # - target=all
 #   The commands are executed on evey node provided
@@ -80,31 +80,31 @@ target=$PHD_ENV_nodes1
 
 pcs resource create redis redis wait_last_known_master=true --master meta notify=true ordered=true interleave=true
 pcs resource create vip-redis IPaddr2 ip=${PHD_VAR_network_internal}.217
-pcs resource create ceilometer-central systemd:openstack-ceilometer-central --clone interleave=true
-pcs resource create ceilometer-collector systemd:openstack-ceilometer-collector --clone interleave=true
-pcs resource create ceilometer-api systemd:openstack-ceilometer-api --clone interleave=true
-pcs resource create ceilometer-delay Delay startdelay=10 --clone interleave=true
-pcs resource create ceilometer-alarm-evaluator systemd:openstack-ceilometer-alarm-evaluator --clone interleave=true
-pcs resource create ceilometer-alarm-notifier systemd:openstack-ceilometer-alarm-notifier --clone interleave=true
-pcs resource create ceilometer-notification systemd:openstack-ceilometer-notification  --clone interleave=true
+pcs resource create openstack-ceilometer-central systemd:openstack-ceilometer-central --clone interleave=true
+pcs resource create openstack-ceilometer-collector systemd:openstack-ceilometer-collector --clone interleave=true
+pcs resource create openstack-ceilometer-api systemd:openstack-ceilometer-api --clone interleave=true
+pcs resource create delay Delay startdelay=10 --clone interleave=true
+pcs resource create openstack-ceilometer-alarm-evaluator systemd:openstack-ceilometer-alarm-evaluator --clone interleave=true
+pcs resource create openstack-ceilometer-alarm-notifier systemd:openstack-ceilometer-alarm-notifier --clone interleave=true
+pcs resource create openstack-ceilometer-notification systemd:openstack-ceilometer-notification  --clone interleave=true
 
 pcs constraint order promote redis-master then start vip-redis
 pcs constraint colocation add vip-redis with master redis-master
-pcs constraint order start vip-redis then ceilometer-central-clone kind=Optional
-pcs constraint order start ceilometer-central-clone then ceilometer-collector-clone
-pcs constraint order start ceilometer-collector-clone then ceilometer-api-clone
-pcs constraint colocation add ceilometer-api-clone with ceilometer-collector-clone 
-pcs constraint order start ceilometer-api-clone then ceilometer-delay-clone
-pcs constraint colocation add ceilometer-delay-clone with ceilometer-api-clone
-pcs constraint order start ceilometer-delay-clone then ceilometer-alarm-evaluator-clone
-pcs constraint colocation add ceilometer-alarm-evaluator-clone with ceilometer-delay-clone
-pcs constraint order start ceilometer-alarm-evaluator-clone then ceilometer-alarm-notifier-clone
-pcs constraint colocation add ceilometer-alarm-notifier-clone with ceilometer-alarm-evaluator-clone
-pcs constraint order start ceilometer-alarm-notifier-clone then ceilometer-notification-clone
-pcs constraint colocation add ceilometer-notification-clone with ceilometer-alarm-notifier-clone
+pcs constraint order start vip-redis then openstack-ceilometer-central-clone kind=Optional
+pcs constraint order start openstack-ceilometer-central-clone then openstack-ceilometer-collector-clone
+pcs constraint order start openstack-ceilometer-collector-clone then openstack-ceilometer-api-clone
+pcs constraint colocation add openstack-ceilometer-api-clone with openstack-ceilometer-collector-clone
+pcs constraint order start openstack-ceilometer-api-clone then delay-clone
+pcs constraint colocation add openstack-ceilometer-delay-clone with openstack-ceilometer-api-clone
+pcs constraint order start openstack-ceilometer-delay-clone then openstack-ceilometer-alarm-evaluator-clone
+pcs constraint colocation add openstack-ceilometer-alarm-evaluator-clone with openstack-ceilometer-delay-clone
+pcs constraint order start openstack-ceilometer-alarm-evaluator-clone then openstack-ceilometer-alarm-notifier-clone
+pcs constraint colocation add openstack-ceilometer-alarm-notifier-clone with openstack-ceilometer-alarm-evaluator-clone
+pcs constraint order start openstack-ceilometer-alarm-notifier-clone then openstack-ceilometer-notification-clone
+pcs constraint colocation add openstack-ceilometer-notification-clone with openstack-ceilometer-alarm-notifier-clone
 
 if [ $PHD_VAR_deployment = collapsed ]; then
-    pcs constraint order start mongodb-clone then ceilometer-central-clone
-    pcs constraint order start keystone-clone then ceilometer-central-clone
+    pcs constraint order start mongod-clone then openstack-ceilometer-central-clone
+    pcs constraint order start openstack-keystone-clone then openstack-ceilometer-central-clone
 fi
 ....

--- a/pcmk/cinder.scenario
+++ b/pcmk/cinder.scenario
@@ -103,19 +103,19 @@ target=$PHD_ENV_nodes1
 su cinder -s /bin/sh -c "cinder-manage db sync"
 
 # create services in pacemaker
-pcs resource create cinder-api systemd:openstack-cinder-api --clone interleave=true
-pcs resource create cinder-scheduler systemd:openstack-cinder-scheduler --clone interleave=true
+pcs resource create openstack-cinder-api systemd:openstack-cinder-api --clone interleave=true
+pcs resource create openstack-cinder-scheduler systemd:openstack-cinder-scheduler --clone interleave=true
 
 # Volume must be A/P for now. See https://bugzilla.redhat.com/show_bug.cgi?id=1193229
-pcs resource create cinder-volume systemd:openstack-cinder-volume
+pcs resource create openstack-cinder-volume systemd:openstack-cinder-volume
 
-pcs constraint order start cinder-api-clone then cinder-scheduler-clone
-pcs constraint colocation add cinder-scheduler-clone with cinder-api-clone
-pcs constraint order start cinder-scheduler-clone then cinder-volume
-pcs constraint colocation add cinder-volume with cinder-scheduler-clone
+pcs constraint order start openstack-cinder-api-clone then openstack-cinder-scheduler-clone
+pcs constraint colocation add openstack-cinder-scheduler-clone with openstack-cinder-api-clone
+pcs constraint order start openstack-cinder-scheduler-clone then openstack-cinder-volume
+pcs constraint colocation add openstack-cinder-volume with openstack-cinder-scheduler-clone
 
 if [ $PHD_VAR_deployment = collapsed ]; then
-    pcs constraint order start keystone-clone then cinder-api-clone
+    pcs constraint order start openstack-keystone-clone then openstack-cinder-api-clone
 fi
 ....
 

--- a/pcmk/controller-managed.scenario
+++ b/pcmk/controller-managed.scenario
@@ -71,7 +71,7 @@ for i in glance-api-clone neutron-metadata-agent-clone nova-conductor-clone; do
 done
 
 # Take down the ODP control plane
-pcs resource disable keystone --wait=240
+pcs resource disable openstack-keystone --wait=240
 
 # Take advantage of the fact that control nodes will already be part of the cluster
 # At this step, we need to teach the cluster about the compute nodes
@@ -187,10 +187,10 @@ for node in ${PHD_ENV_nodes}; do
     fi
 done
 
-pcs resource enable keystone
+pcs resource enable openstack-keystone
 pcs resource enable neutron-openvswitch-agent-compute
 pcs resource enable libvirtd-compute
-pcs resource enable ceilometer-compute
+pcs resource enable openstack-ceilometer-compute
 pcs resource enable nova-compute-fs
 pcs resource enable nova-compute
 

--- a/pcmk/galera.scenario
+++ b/pcmk/galera.scenario
@@ -45,7 +45,7 @@ yum install -y mariadb-galera-server xinetd rsync
 
 if [ $PHD_VAR_deployment = collapsed ]; then
    # Allowing the proxy to perform health checks on galera while we're initializing it is... problematic. 
-   pcs resource disable lb-haproxy
+   pcs resource disable haproxy
 fi
 
 cat > /etc/sysconfig/clustercheck << EOF
@@ -136,7 +136,7 @@ pcs resource create galera galera enable_creation=true wsrep_cluster_address="gc
 
 if [ $PHD_VAR_deployment = collapsed ]; then
    # Now we can re-enable the proxy
-   pcs resource enable lb-haproxy
+   pcs resource enable haproxy
 fi
 
 # wait for galera to start and become promoted

--- a/pcmk/glance.scenario
+++ b/pcmk/glance.scenario
@@ -106,16 +106,16 @@ chown glance:nobody /var/lib/glance
 # Now populate the database
 su glance -s /bin/sh -c "glance-manage db_sync"
 
-pcs resource create glance-registry systemd:openstack-glance-registry --clone interleave=true
-pcs resource create glance-api systemd:openstack-glance-api --clone interleave=true
+pcs resource create openstack-glance-registry systemd:openstack-glance-registry --clone interleave=true
+pcs resource create openstack-glance-api systemd:openstack-glance-api --clone interleave=true
 
-pcs constraint order start glance-fs-clone then glance-registry-clone
-pcs constraint colocation add glance-registry-clone with glance-fs-clone
-pcs constraint order start glance-registry-clone then glance-api-clone
-pcs constraint colocation add glance-api-clone with glance-registry-clone
+pcs constraint order start openstack-glance-fs-clone then openstack-glance-registry-clone
+pcs constraint colocation add openstack-glance-registry-clone with openstack-glance-fs-clone
+pcs constraint order start openstack-glance-registry-clone then openstack-glance-api-clone
+pcs constraint colocation add openstack-glance-api-clone with openstack-glance-registry-clone
 
 if [ $PHD_VAR_deployment = collapsed ]; then
-   pcs constraint order start keystone-clone then glance-registry-clone
+   pcs constraint order start openstack-keystone-clone then openstack-glance-registry-clone
 fi
 ....
 

--- a/pcmk/heat.scenario
+++ b/pcmk/heat.scenario
@@ -78,20 +78,20 @@ target=$PHD_ENV_nodes1
 ....
 su heat -s /bin/sh -c "heat-manage db_sync"
 
-pcs resource create heat-api systemd:openstack-heat-api --clone interleave=true
-pcs resource create heat-api-cfn systemd:openstack-heat-api-cfn  --clone interleave=true
-pcs resource create heat-api-cloudwatch systemd:openstack-heat-api-cloudwatch --clone interleave=true
-pcs resource create heat-engine systemd:openstack-heat-engine --clone interleave=true
+pcs resource create openstack-heat-api systemd:openstack-heat-api --clone interleave=true
+pcs resource create openstack-heat-api-cfn systemd:openstack-heat-api-cfn  --clone interleave=true
+pcs resource create openstack-heat-api-cloudwatch systemd:openstack-heat-api-cloudwatch --clone interleave=true
+pcs resource create openstack-heat-engine systemd:openstack-heat-engine --clone interleave=true
 
-pcs constraint order start heat-api-clone then heat-api-cfn-clone
-pcs constraint colocation add heat-api-cfn-clone with heat-api-clone
-pcs constraint order start heat-api-cfn-clone then heat-api-cloudwatch-clone
-pcs constraint colocation add heat-api-cloudwatch-clone with heat-api-cfn-clone
-pcs constraint order start heat-api-cloudwatch-clone then heat-engine-clone
-pcs constraint colocation add heat-engine-clone with heat-api-cloudwatch-clone
+pcs constraint order start openstack-heat-api-clone then openstack-heat-api-cfn-clone
+pcs constraint colocation add openstack-heat-api-cfn-clone with openstack-heat-api-clone
+pcs constraint order start openstack-heat-api-cfn-clone then openstack-heat-api-cloudwatch-clone
+pcs constraint colocation add openstack-heat-api-cloudwatch-clone with openstack-heat-api-cfn-clone
+pcs constraint order start openstack-heat-api-cloudwatch-clone then openstack-heat-engine-clone
+pcs constraint colocation add openstack-heat-engine-clone with openstack-heat-api-cloudwatch-clone
 
 if [ $PHD_VAR_deployment = collapsed ]; then
-    pcs constraint order start ceilometer-notification-clone then heat-api-clone
+    pcs constraint order start openstack-ceilometer-notification-clone then openstack-heat-api-clone
 fi
 ....
 

--- a/pcmk/horizon.scenario
+++ b/pcmk/horizon.scenario
@@ -85,5 +85,5 @@ EOF
 
 target=$PHD_ENV_nodes1
 ....
-pcs resource create horizon apache --clone interleave=true
+pcs resource create httpd apache --clone interleave=true
 ....

--- a/pcmk/keystone.scenario
+++ b/pcmk/keystone.scenario
@@ -96,7 +96,7 @@ target=$PHD_ENV_nodes1
 ....
 su keystone -s /bin/sh -c "keystone-manage -v -d db_sync"
 
-pcs resource create keystone systemd:openstack-keystone --clone interleave=true
+pcs resource create openstack-keystone systemd:openstack-keystone --clone interleave=true
 
 if [ $PHD_VAR_deployment = collapsed ]; then
 
@@ -104,10 +104,10 @@ if [ $PHD_VAR_deployment = collapsed ]; then
     # things in a particular order and require services to be active
     # on the same hosts.  We do this with constraints.
 
-    pcs constraint order start lb-haproxy-clone then keystone-clone
-    pcs constraint order promote galera-master then keystone-clone
-    pcs constraint order start rabbitmq-server-clone then keystone-clone
-    pcs constraint order start memcached-clone then keystone-clone
+    pcs constraint order start haproxy-clone then openstack-keystone-clone
+    pcs constraint order promote galera-master then openstack-keystone-clone
+    pcs constraint order start rabbitmq-clone then openstack-keystone-clone
+    pcs constraint order start memcached-clone then openstack-keystone-clone
 fi
 
 export OS_TOKEN=${PHD_VAR_secrets_keystone_secret}

--- a/pcmk/lb.scenario
+++ b/pcmk/lb.scenario
@@ -196,7 +196,7 @@ fi
 
 target=$PHD_ENV_nodes1
 ....
-pcs resource create lb-haproxy systemd:haproxy --clone
+pcs resource create haproxy systemd:haproxy --clone
 
 
 # The VIPs changed recently 
@@ -241,8 +241,8 @@ if [ $PHD_VAR_deployment = collapsed ]; then
 		: No VIP constraints needed for $section
 		;;
 	    *)
-		pcs constraint order start vip-${section} then lb-haproxy-clone kind=Optional
-    		pcs constraint colocation add vip-${section} with lb-haproxy-clone
+		pcs constraint order start vip-${section} then haproxy-clone kind=Optional
+		pcs constraint colocation add vip-${section} with haproxy-clone
 		;;
 	esac
     done

--- a/pcmk/mongodb.scenario
+++ b/pcmk/mongodb.scenario
@@ -49,7 +49,7 @@ systemctl stop mongod
 
 target=$PHD_ENV_nodes1
 ....
-pcs resource create mongodb systemd:mongod op start timeout=300s --clone
+pcs resource create mongod systemd:mongod op start timeout=300s --clone
 
 # Setup replica (need to wait for mongodb to settle down first!)
 sleep 20

--- a/pcmk/neutron-server.scenario
+++ b/pcmk/neutron-server.scenario
@@ -149,6 +149,6 @@ systemctl stop neutron-server
 pcs resource create neutron-server systemd:neutron-server op start timeout=90 --clone interleave=true
 
 if [ $PHD_VAR_deployment = collapsed ]; then
-   pcs constraint order start keystone-clone then neutron-server-clone
+   pcs constraint order start openstack-keystone-clone then neutron-server-clone
 fi
 ....

--- a/pcmk/nova.scenario
+++ b/pcmk/nova.scenario
@@ -102,25 +102,25 @@ target=$PHD_ENV_nodes1
 ....
 su nova -s /bin/sh -c "nova-manage db sync"
 
-pcs resource create nova-consoleauth systemd:openstack-nova-consoleauth --clone interleave=true
-pcs resource create nova-novncproxy systemd:openstack-nova-novncproxy --clone interleave=true
-pcs resource create nova-api systemd:openstack-nova-api --clone interleave=true
-pcs resource create nova-scheduler systemd:openstack-nova-scheduler --clone interleave=true
-pcs resource create nova-conductor systemd:openstack-nova-conductor --clone interleave=true
+pcs resource create openstack-nova-consoleauth systemd:openstack-nova-consoleauth --clone interleave=true
+pcs resource create openstack-nova-novncproxy systemd:openstack-nova-novncproxy --clone interleave=true
+pcs resource create openstack-nova-api systemd:openstack-nova-api --clone interleave=true
+pcs resource create openstack-nova-scheduler systemd:openstack-nova-scheduler --clone interleave=true
+pcs resource create openstack-nova-conductor systemd:openstack-nova-conductor --clone interleave=true
 
-pcs constraint order start nova-consoleauth-clone then nova-novncproxy-clone
-pcs constraint colocation add nova-novncproxy-clone with nova-consoleauth-clone
+pcs constraint order start openstack-nova-consoleauth-clone then openstack-nova-novncproxy-clone
+pcs constraint colocation add openstack-nova-novncproxy-clone with openstack-nova-consoleauth-clone
 
-pcs constraint order start nova-novncproxy-clone then nova-api-clone
-pcs constraint colocation add nova-api-clone with nova-novncproxy-clone
+pcs constraint order start openstack-nova-novncproxy-clone then openstack-nova-api-clone
+pcs constraint colocation add openstack-nova-api-clone with openstack-nova-novncproxy-clone
 
-pcs constraint order start nova-api-clone then nova-scheduler-clone
-pcs constraint colocation add nova-scheduler-clone with nova-api-clone
+pcs constraint order start openstack-nova-api-clone then openstack-nova-scheduler-clone
+pcs constraint colocation add openstack-nova-scheduler-clone with openstack-nova-api-clone
 
-pcs constraint order start nova-scheduler-clone then nova-conductor-clone
-pcs constraint colocation add nova-conductor-clone with nova-scheduler-clone
+pcs constraint order start openstack-nova-scheduler-clone then openstack-nova-conductor-clone
+pcs constraint colocation add openstack-nova-conductor-clone with openstack-nova-scheduler-clone
 
 if [ $PHD_VAR_deployment = collapsed ]; then
-    pcs constraint order start keystone-clone then nova-consoleauth-clone
+    pcs constraint order start openstack-keystone-clone then openstack-nova-consoleauth-clone
 fi
 ....

--- a/pcmk/rabbitmq.scenario
+++ b/pcmk/rabbitmq.scenario
@@ -68,5 +68,5 @@ cat $PHD_VAR_osp_configdir/rabbitmq_erlang_cookie > /var/lib/rabbitmq/.erlang.co
 
 target=$PHD_ENV_nodes1
 ....
-pcs resource create rabbitmq-server rabbitmq-cluster set_policy='HA ^(?!amq\.).* {"ha-mode":"all"}' meta notify=true --clone ordered=true interleave=true
+pcs resource create rabbitmq rabbitmq-cluster set_policy='ha-all ^(?!amq\.).* {"ha-mode":"all"}' meta notify=true --clone ordered=true interleave=true
 ....

--- a/pcmk/swift-aco.scenario
+++ b/pcmk/swift-aco.scenario
@@ -98,7 +98,7 @@ if ! pcs resource show swift-fs > /dev/null 2>&1; then
     pcs constraint colocation add swift-object-clone with swift-container-clone
     pcs constraint order start swift-container-clone then swift-object-clone
     if [ $PHD_VAR_deployment = collapsed ]; then
-	pcs constraint order start keystone-clone then swift-account-clone
+	pcs constraint order start openstack-keystone-clone then swift-account-clone
    fi
 fi
 ....


### PR DESCRIPTION
Rename pcs resources so that the differences between a CIB
produced by tripleo and one produced by this refarch are much smaller.
The remaining delta is mainly around VIP naming which is dynamic
with tripleo
